### PR TITLE
add local workspace config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 *.swo
 *~
 .taskmaestro/
+.claude
+.mcp.json
+
+# Codingbuddy (local workspace)
+codingbuddy.config.json
+docs/codingbuddy/
+.codingbuddy/


### PR DESCRIPTION
## Summary
- Add `.claude`, `.mcp.json` to `.gitignore` for local Claude Code config isolation
- Add `codingbuddy.config.json`, `docs/codingbuddy/`, `.codingbuddy/` to `.gitignore` for local CodingBuddy workspace files

## Test plan
- [x] Verify `.gitignore` entries correctly exclude local workspace files
- [x] Confirm no sensitive or tracked files are affected