### PR TITLE
feat: add shell script safety rules and session management

### DIFF
--- a/skills/taskmaestro/SKILL.md
+++ b/skills/taskmaestro/SKILL.md
@@ -94,6 +94,43 @@ Include this instruction in every worker task directive:
 
 ---
 
+## Shell Script Safety Rules
+
+### Array Indexing Ban
+
+Array indexing behaves differently between bash and zsh, causing silent bugs:
+
+```bash
+# ❌ BANNED — index mismatch between shells
+# bash: arr[0] is first element
+# zsh:  arr[1] is first element (0-indexed requires setopt)
+PANES=(1 2 3)
+echo "${PANES[0]}"  # Different result in bash vs zsh!
+
+# ✅ REQUIRED — explicit key:value mapping
+PANE_1_TASK="implement API"
+PANE_2_TASK="write tests"
+# Or use associative arrays with explicit keys
+```
+
+**Rule:** Never use numeric array indexing in shell scripts. Use explicit variable names or associative arrays with string keys.
+
+---
+
+## Session Management
+
+### Compact Cadence
+
+For long-running orchestration sessions, context can grow large. Follow these guidelines:
+
+- **Watch mode** produces periodic status reports — keep them concise (summary table only)
+- **Conductor decisions** should be logged to `~/.claude/taskmaestro-state.json`, not kept in conversation context
+- When the conductor's context gets large, summarize completed waves and focus on the current wave
+- CronCreate jobs are tied to the current Claude Code session and auto-expire after 7 days
+- If the session ends or expires, watch mode stops — run `/taskmaestro watch` again to restart
+
+---
+
 ## Subcommand: start
 
 `/taskmaestro start [--repo <path>] [--base <branch>] [--panes <1,2,3>]`


### PR DESCRIPTION
## Summary
- Add shell script safety rules: ban array indexing (bash/zsh index mismatch)
- Require explicit key:value mapping instead of numeric array indices
- Add session management guidelines for long-running orchestration
- Document CronCreate session dependency and 7-day auto-expiry
- Compact cadence recommendations for context management

## Test plan
- [ ] Skill file renders correctly with new sections
- [ ] Rules are actionable and prevent known bash/zsh pitfalls

Closes #15